### PR TITLE
Uncommented bpf_printk statements in main search loop so output match…

### DIFF
--- a/src/map_delete_elem.c
+++ b/src/map_delete_elem.c
@@ -2,7 +2,7 @@
  /*
   *
   *   This program deletes a rule from an existing pinned 
-  *   zt_tproxy_map hash table created by the redirect_udp
+  *   zt_tproxy_map hash table created by the tproxy_splicer
   *   program when attatched to an interface via tc
   *
   *   This program is free software: you can redistribute it and/or modify

--- a/src/map_update.c
+++ b/src/map_update.c
@@ -2,7 +2,7 @@
  /*
   *
   *   This program inserts a rule into an existing pinned 
-  *   zt_tproxy_map hash table created by the redirect_udp
+  *   zt_tproxy_map hash table created by the tproxy_splicer
   *   program when attatched to an interface via tc
   *
   *   This program is free software: you can redistribute it and/or modify

--- a/src/tproxy_splicer.c
+++ b/src/tproxy_splicer.c
@@ -423,8 +423,8 @@ int bpf_sk_splice(struct __sk_buff *skb){
                          */
                         if ((bpf_ntohs(tuple->ipv4.dport) >= bpf_ntohs(tproxy->udp_mapping[port_key].low_port))
                          && (bpf_ntohs(tuple->ipv4.dport) <= bpf_ntohs(tproxy->udp_mapping[port_key].high_port))) {
-                            /* bpf_printk("udp_tproxy_mapping->%d to %d", bpf_ntohs(tuple->ipv4.dport),
-                               bpf_ntohs(tproxy->udp_mapping[port_key].tproxy_port)); */
+                            bpf_printk("udp_tproxy_mapping->%d to %d", bpf_ntohs(tuple->ipv4.dport),
+                               bpf_ntohs(tproxy->udp_mapping[port_key].tproxy_port));
                             if(local){
                                 return TC_ACT_OK;
                             }
@@ -453,8 +453,8 @@ int bpf_sk_splice(struct __sk_buff *skb){
                          * if successfull jump to assign: 
                          */
                         if ((bpf_ntohs(tuple->ipv4.dport) >= bpf_ntohs(tproxy->tcp_mapping[port_key].low_port)) && (bpf_ntohs(tuple->ipv4.dport) <= bpf_ntohs(tproxy->tcp_mapping[port_key].high_port))) {
-                            /*bpf_printk("tcp_tproxy_mapping->%d to %d", bpf_ntohs(tuple->ipv4.dport),
-                              bpf_ntohs(tproxy->tcp_mapping[port_key].tproxy_port));*/
+                            bpf_printk("tcp_tproxy_mapping->%d to %d", bpf_ntohs(tuple->ipv4.dport),
+                              bpf_ntohs(tproxy->tcp_mapping[port_key].tproxy_port));
                             if(local){
                                 return TC_ACT_OK;
                             }


### PR DESCRIPTION
…es monitor section of README.md.  Also fixed references to udp redirect in comments in map_update.c and map_delete_elem.c