### PR TITLE
refactored struct ifindex_ip4 field ifindex to char ifname[IF_NAMESIZ…

### DIFF
--- a/src/map_update.c
+++ b/src/map_update.c
@@ -48,7 +48,7 @@
 
 struct ifindex_ip4 {
     __u32 ipaddr;
-    __u32 ifindex;
+    char ifname[IF_NAMESIZE];
 };
 
 struct tproxy_port_mapping {
@@ -219,8 +219,9 @@ int main(int argc, char **argv){
                 getnameinfo(address->ifa_addr,family_size,ap,sizeof(ap),0,0,1);
                 struct ifindex_ip4 ifip4 = {
                     htonl(ip2l(ap)),
-                    idx,
+		    {0}
                 };          
+		sprintf(ifip4.ifname, "%s", address->ifa_name);
                 if_map.key = (uint64_t)&idx;
                 if_map.flags = BPF_ANY;
                 if_map.value = (uint64_t)&ifip4;

--- a/src/tproxy_splicer.c
+++ b/src/tproxy_splicer.c
@@ -28,7 +28,8 @@
 #include <bpf/bpf_endian.h>
 #include <iproute2/bpf_elf.h>
 #include <stdbool.h>
-#include <linux/tcp.h>\
+#include <linux/tcp.h>
+#include <net/if.h>
 
 #define BPF_MAP_ID_TPROXY  1
 #define BPF_MAP_ID_IFINDEX_IP  2
@@ -75,7 +76,7 @@ struct tproxy_key {
 /*value to ifindex_ip_map*/
 struct ifindex_ip4 {
     __u32 ipaddr;
-    __u32 ifindex;
+    char ifname[IF_NAMESIZE];
 };
 
 /* File system pinned Array Map key mapping to ifindex with used to allow 
@@ -317,7 +318,7 @@ int bpf_sk_splice(struct __sk_buff *skb){
 
     
     if((local_ip4) && (tuple->ipv4.daddr == local_ip4->ipaddr)){
-        local = true;
+       local = true;
        /* if ip of attached interface found in map only allow ssh to that IP */
        if((bpf_ntohs(tuple->ipv4.dport) == 22)){
             return TC_ACT_OK;


### PR DESCRIPTION
…E] since key matches ifindex it was redundant and it could be usefull to have ifname available to bpf program.