### PR TITLE
added -g to clang for compile of main ebpf program because in cloud i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For those interested in additional background on the project please visit: https
         cd repos
         git clone https://github.com/r-caamano/ebpf-tproxy-splicer.git 
         cd ebpf-tproxy-splicer/src
-        clang -O2 -Wall -Wextra -target bpf -c -o tproxy_splicer.o tproxy_splicer.c
+        clang -g -O2 -Wall -Wextra -target bpf -c -o tproxy_splicer.o tproxy_splicer.c
         clang -O2 -Wall -Wextra -o map_update map_update.c
         clang -O2 -Wall -Wextra -o map_delete_elem map_delete_elem.c 
        


### PR DESCRIPTION
….e. aws for some reason it does not compile btf without -g although it does on other platforms i.e. vbox/vmware with same clang version