### PR TITLE
fixed out of order tail call causing prefixes with len 9 - 16 inclusi…

### DIFF
--- a/src/map_update.c
+++ b/src/map_update.c
@@ -106,7 +106,7 @@ static char *prefix_interface;
 static char *tc_interface;
 static char *object_file;
 static char *direction_string;
-const char *argp_program_version = "0.2.6";
+const char *argp_program_version = "0.2.7";
 
 static __u8 if_list[MAX_IF_LIST_ENTRIES];
 int ifcount = 0;

--- a/src/tproxy_splicer.c
+++ b/src/tproxy_splicer.c
@@ -868,7 +868,7 @@ int bpf_sk_splice2(struct __sk_buff *skb){
             each octet.
             */
             if(dmask == 0x80ffff){
-                bpf_tail_call(skb, &prog_map, 4);
+                bpf_tail_call(skb, &prog_map, 3);
                 break;
             }
             iterate_masks(&dmask, &dexponent);


### PR DESCRIPTION
…ve to fail due to skipped checks in prog 3